### PR TITLE
Required labels example

### DIFF
--- a/example-required.md
+++ b/example-required.md
@@ -1,0 +1,1 @@
+:label:  :no_entry_sign:


### PR DESCRIPTION
This PR doesn't have all of the required labels attached to it. 

We need any one of `any` or `any_2`, and both of `all` and `required`. You can see that this one is missing the `all` label. 

This repo is set up with the following configuration
REQUIRED_LABELS_ANY: `any`, `any_2`
REQUIRED_LABELS_ALL: `all`, `required`
BANNED_LABELS: `banned`

You can also see the config for this app [here](http://required-labels-repo.herokuapp.com/config).