### PR TITLE
Banned labels Example

### DIFF
--- a/banned-labels-example
+++ b/banned-labels-example
@@ -1,0 +1,1 @@
+This PR contains a banned label, preventing it from being merged. 


### PR DESCRIPTION
This PR has the `banned` label attached to it, meaning it doesn't pass the label requirements.

This repo is set up with the following configuration
REQUIRED_LABELS_ANY: any, any_2
REQUIRED_LABELS_ALL: all, required
BANNED_LABELS: banned

You can also see the config for this app here.