### PR TITLE
Label requirements passed example

### DIFF
--- a/label-requirements-passed
+++ b/label-requirements-passed
@@ -1,0 +1,1 @@
+This PR passes all label requirements


### PR DESCRIPTION
This label passes all label requirements. 

We need any one of `any` or `any_2`, and both of `all` and `required`. It cannot have the `banned` label. 

This repo is set up with the following configuration
REQUIRED_LABELS_ANY: any, any_2
REQUIRED_LABELS_ALL: all, required
BANNED_LABELS: banned

You can also see the config for this app here.