### PR TITLE
[Enh] configuration management

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ $ pip install -r requirements.txt
 $ cp custom.conf.template custom.conf
 ```
 Then modify `custom.conf` with your own settings.
+Default behavior is to source this file from project cloned directory.
+
+You can source a custom file path using `CONFIG_FILE` environment variable.
+
+```sh
+$ export CONFIG_FILE=/some/path/to/config.conf
+```
+
 You can also set `REQUIRED_LABELS_ALL`, `REQUIRED_LABELS_ANY`, or `BANNED_LABELS` along with `GITHUB_USER` and `GITHUB_PW` directly as environment variables:
 
 ```sh

--- a/config.py
+++ b/config.py
@@ -1,8 +1,10 @@
 import os
 import sys
 from configparser import ConfigParser, NoSectionError
+from pathlib import Path
 
 
+APP_BASEDIR = Path(os.path.abspath(__file__)).parent
 APP_NAME = "dimagi/required-labels"
 
 
@@ -12,7 +14,7 @@ class ConfigException(Exception):
 
 config_filename = "custom.conf"
 config = ConfigParser()
-config.read(config_filename)
+config.read(os.path.join(APP_BASEDIR, config_filename))
 
 try:
     required_any = config.get('Labels', 'required-labels-any')

--- a/main.py
+++ b/main.py
@@ -1,7 +1,9 @@
 import os
+
 from flask import Flask, request
+
 from utils import PullRequest
-from config import REQUIRED_LABELS_ALL, REQUIRED_LABELS_ANY, BANNED_LABELS
+from config import CONFIG
 
 app = Flask(__name__)
 
@@ -12,7 +14,8 @@ def main():
     if event_warrants_label_check(event_json):
         pull_request = PullRequest(event_json)
         print("Checking labels for PR {}".format(pull_request.issue_url))
-        status_code = pull_request.compute_and_post_status(REQUIRED_LABELS_ANY, REQUIRED_LABELS_ALL, BANNED_LABELS)
+        status_code = pull_request.compute_and_post_status(
+            CONFIG['required_any'], CONFIG['required_all'], CONFIG['banner'])
         return str(status_code)
     else:
         return 'No label check needed'
@@ -24,7 +27,9 @@ def config():
     Any: {}<br/>
     All: {}<br/>
     Banned: {}<br/>
-    """.format(REQUIRED_LABELS_ANY, REQUIRED_LABELS_ALL, BANNED_LABELS)
+    """.format(CONFIG['required_any'],
+               CONFIG['required_all'],
+               CONFIG['banner'])
 
 
 def event_warrants_label_check(pr_event_json):

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ def main():
         pull_request = PullRequest(event_json)
         print("Checking labels for PR {}".format(pull_request.issue_url))
         status_code = pull_request.compute_and_post_status(
-            CONFIG['required_any'], CONFIG['required_all'], CONFIG['banner'])
+            CONFIG['required_any'], CONFIG['required_all'], CONFIG['banned'])
         return str(status_code)
     else:
         return 'No label check needed'
@@ -29,7 +29,7 @@ def config():
     Banned: {}<br/>
     """.format(CONFIG['required_any'],
                CONFIG['required_all'],
-               CONFIG['banner'])
+               CONFIG['banned'])
 
 
 def event_warrants_label_check(pr_event_json):

--- a/tests/fixtures/custom.conf.test
+++ b/tests/fixtures/custom.conf.test
@@ -1,0 +1,10 @@
+[Labels]
+# For each parameter, either provide a list of comma-separated labels, or leave blank if not using
+required-labels-any:
+required-labels-all:
+banned-labels:
+
+[GitHub]
+# Include the username and password of a user that has push access to the repository in which your Webhook is configured
+user: someuser
+password:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,33 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from config import generate_config, APP_BASEDIR
+
+
+class TestGenerateConfig(unittest.TestCase):
+    @patch('config.ConfigParser')
+    def test_it_reads_default_config_file(self, configparser):
+        generate_config()
+        configparser.return_value.read.assert_called_once_with(
+            os.path.join(APP_BASEDIR, 'custom.conf'))
+
+    @patch('config.ConfigParser')
+    def test_it_reads_given_config_file_from_environment_var(self,
+                                                             configparser):
+        with patch.dict(os.environ, {'CONFIG_FILE': '/someconf'}):
+            generate_config()
+            configparser.return_value.read.assert_called_once_with('/someconf')
+
+    def test_it_source_config_from_environment_with_missing_conf(self):
+        with patch.dict(os.environ, {'CONFIG_FILE': '/conf/notexist',
+                                     'GITHUB_USER': 'ghuser'}):
+            config = generate_config()
+            assert config['github_user'] == 'ghuser'
+
+    def test_it_source_config_from_given_config_file(self):
+        fixture_config = os.path.join(APP_BASEDIR, 'tests', 'fixtures',
+                                      'custom.conf.test')
+        with patch.dict(os.environ, {'CONFIG_FILE': fixture_config}):
+            config = generate_config()
+            assert config['github_user'] == 'someuser'


### PR DESCRIPTION
- default ```custom.conf``` can be source without having to cd in project dir
- accept config path/name from environment var ```CONFIG_FILE```
- update doc
- refacto config in functions
- add unit  tests for config