### PR TITLE
any() takes exactly one argument (2 given)

### DIFF
--- a/config.py
+++ b/config.py
@@ -67,7 +67,8 @@ UNIT_TESTING = any([arg for arg in sys.argv if 'test' in arg])
 if not UNIT_TESTING:
     labels_configured = any([CONFIG['required_any'], CONFIG['required_all'],
                              CONFIG['banned']])
-    credentials_configured = any(all([CONFIG['github_pw'], CONFIG['github_user']]), CONFIG['github_token'])
+    credentials_configured = any([all([CONFIG['github_pw'], CONFIG['github_user']]),
+                                  CONFIG['github_token']])
     if not labels_configured or not credentials_configured:
         raise ConfigException(
             "Please ensure your config file has a [Labels] and [Github] section.\n"


### PR DESCRIPTION
Looks like this was introduced in https://github.com/dimagi/required-labels/pull/24